### PR TITLE
Removed deprecated has_rdoc line

### DIFF
--- a/spree_social.gemspec
+++ b/spree_social.gemspec
@@ -14,8 +14,6 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.has_rdoc = true
-
   s.add_dependency('spree_core', '>= 0.40.0')
   s.add_dependency('spree_auth', '>= 0.40.0')
   s.add_dependency('oa-oauth', '>= 0.2.2')


### PR DESCRIPTION
Minor edit.

"Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2011-10-01."
