### PR TITLE
Added vkontakte adapter

### DIFF
--- a/lib/spree_social.rb
+++ b/lib/spree_social.rb
@@ -9,7 +9,7 @@ module SpreeSocial
     ["Bit.ly", "bitly"], ["Evernote", "evernote"], ["Facebook", "facebook"], ["Foursquare", "foursquare"],
     ["Github", "github"], ["Google", "google"] , ["Gowalla", "gowalla"], ["instagr.am", "instagram"],
     ["Instapaper", "instapaper"], ["LinkedIn", "linked_in"], ["37Signals (Basecamp, Campfire, etc)", "thirty_seven_signals"],
-    ["Twitter", "twitter"], ["Vimeo", "vimeo"], ["Yahoo!", "yahoo"], ["YouTube", "you_tube"]
+    ["Twitter", "twitter"], ["Vimeo", "vimeo"], ["Yahoo!", "yahoo"], ["YouTube", "you_tube"], ["Vkontakte", "vkontakte"]
   ]
 
 


### PR DESCRIPTION
Vkontakte is Russian social service. Since intridea/omniauth@99a316f5b1d85410c932abcd9590d10f2e416754 have integrated and tested in omniauth.
Adapter tested with spree_social and works fine out of the box
