### PR TITLE
Fixed `script/rails` to Enable Rails Generators

### DIFF
--- a/script/rails
+++ b/script/rails
@@ -1,5 +1,5 @@
-#!/usr/bin/env ruby
 # This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
 
-ENGINE_PATH = File.expand_path('../..',  __FILE__)
-load File.expand_path('../../spec/dummy/script/rails',  __FILE__)
+APP_PATH = File.expand_path('../../config/application',  __FILE__)
+require File.expand_path('../../config/boot',  __FILE__)
+require 'rails/commands'


### PR DESCRIPTION
Very simple, 

Much like for spree_reviews (see similar pull request),

Including the correct version of the rails script file to enable the Rails generators for spree-1-0 and Rails 3.1+. The version used was suggested by Ryan Bigg (radar): https://github.com/spree/spree/blob/1-0-stable/cmd/lib/spree_cmd/templates/extension/script/rails.tt

Cheers
