### PR TITLE
Fix mass assignment error

### DIFF
--- a/app/models/spree/user_authentication.rb
+++ b/app/models/spree/user_authentication.rb
@@ -1,3 +1,4 @@
 class Spree::UserAuthentication < ActiveRecord::Base
+  attr_accessible :provider, :uid
   belongs_to :user
 end


### PR DESCRIPTION
Due to new mass assignment protection in rails 3.2.3 we have to set 'uid' to 'attr_accessible' in UserAuthentication model.
