### PR TITLE
Noticed a small typo in a Deface override

### DIFF
--- a/app/overrides/user_registrations_decorator.rb
+++ b/app/overrides/user_registrations_decorator.rb
@@ -11,7 +11,7 @@ Deface::Override.new(:virtual_path => "spree/user_sessions/new",
                      :disabled => false)
 
 Deface::Override.new(:virtual_path => "spree/user_registrations/new",
-                     :name => "remove_new_customer_if_seesionomniauth",
+                     :name => "remove_new_customer_if_sessionomniauth",
                      :replace => "div#new-customer h6",
                      :partial => "spree/users/new-customer",
                      :disabled => false)


### PR DESCRIPTION
Hi, I noticed a small typo in a Deface override. Seems like it's not referenced by any other file in spree_social, seems like correcting it will not cause any unintended consequences. 
