### PR TITLE
associate authentication to user with same email

### DIFF
--- a/app/controllers/spree/omniauth_callbacks_controller.rb
+++ b/app/controllers/spree/omniauth_callbacks_controller.rb
@@ -14,7 +14,7 @@ class Spree::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
           authentication = Spree::UserAuthentication.find_by_provider_and_uid(auth_hash['provider'], auth_hash['uid'])
 
-          if !authentication.nil?
+          if authentication.present?
             flash[:notice] = "Signed in successfully"
             sign_in_and_redirect :user, authentication.user
           elsif current_user
@@ -22,7 +22,7 @@ class Spree::OmniauthCallbacksController < Devise::OmniauthCallbacksController
             flash[:notice] = "Authentication successful."
             redirect_back_or_default(account_url)
           else
-            user = Spree::User.new
+            user = Spree::User.find_by_email(auth_hash['info']['email']) || Spree::User.new
             user.apply_omniauth(auth_hash)
             if user.save
               flash[:notice] = "Signed in successfully."


### PR DESCRIPTION
I've encountered the following scenario :

1) An user logs in for the first time with facebook.
2) And delete his facebook authentication methods.
3) Then logs out.

When user tries to login again with his facebook account, it states that the email is already taken and tell him to use a new email (create a new user).

I don't know if this is a personal feature but this PR implement the following solution :
When an user logs in with omniauth, and the email already belongs to an user, it adds a new user_authentication and sign him in.
