### PR TITLE
Rails 3.2 DEPRECATION WARNING fix

### DIFF
--- a/app/controllers/spree/omniauth_callbacks_controller.rb
+++ b/app/controllers/spree/omniauth_callbacks_controller.rb
@@ -54,7 +54,7 @@ class Spree::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def passthru
-    render :file => "#{Rails.root}/public/404.html", :status => 404, :layout => false
+    render :file => "#{Rails.root}/public/404", :formats => [:html], :status => 404, :layout => false
   end
 
   def auth_hash


### PR DESCRIPTION
DEPRECATION WARNING: Passing the format in the template name is
    deprecated. Please pass render with :formats => [:html] instead.
