### PR TITLE
use mobile facebook when navigating from a mobile device

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,10 @@ Spree::Core::Engine.routes.append do
   devise_for :users,
              :class_name => Spree::User,
              :skip => [:unlocks],
-             :controllers => { :sessions => 'spree/user_sessions', :omniauth_callbacks => "spree/omniauth_callbacks", :registrations => 'spree/user_registrations' }
+             :controllers => { :sessions => 'spree/user_sessions', :omniauth_callbacks => "spree/omniauth_callbacks", :registrations => 'spree/user_registrations' } do 
+             	get '/users/auth/:provider' => 'users/omniauth_callbacks#passthru'
+    			get '/users/auth/:provider/setup' => 'users/omniauth_callbacks#setup'
+             end
   resources :user_authentications
 
   match 'account' => 'users#show', :as => 'user_root'

--- a/lib/spree_social/engine.rb
+++ b/lib/spree_social/engine.rb
@@ -40,7 +40,32 @@ module SpreeSocial
 
   def self.setup_key_for(provider, key, secret)
     Devise.setup do |config|
-      config.omniauth provider, key, secret
+      config.omniauth provider, key, secret, :setup => true
+    end
+  end
+end
+
+module OmniAuth
+  module Strategies
+    class Facebook < OAuth2
+
+      MOBILE_USER_AGENTS =  'palm|blackberry|nokia|phone|midp|mobi|symbian|chtml|ericsson|minimo|' +
+                              'audiovox|motorola|samsung|telit|upg1|windows ce|ucweb|astel|plucker|' +
+                              'x320|x240|j2me|sgh|portable|sprint|docomo|kddi|softbank|android|mmp|' +
+                              'pdxgw|netfront|xiino|vodafone|portalmmm|sagem|mot-|sie-|ipod|up\\.b|' +
+                              'webos|amoi|novarra|cdm|alcatel|pocket|ipad|iphone|mobileexplorer|' +
+                              'mobile'
+      def request_phase
+        options[:scope] ||= "email,offline_access"
+        options[:display] = mobile_request? ? 'touch' : 'page'
+        super
+      end
+
+      def mobile_request?
+        ua = Rack::Request.new(@env).user_agent.to_s
+        ua.downcase =~ Regexp.new(MOBILE_USER_AGENTS)
+      end
+
     end
   end
 end


### PR DESCRIPTION
I added an omniauth strategy that reads the user agent and selects the mobile vs desktop view for facebook login.

(currently in use at https://www.wantable.co
