### PR TITLE
Remove override for outdated views

### DIFF
--- a/app/overrides/admin_configuration_decorator.rb
+++ b/app/overrides/admin_configuration_decorator.rb
@@ -4,9 +4,3 @@ Deface::Override.new(:virtual_path => "spree/admin/shared/_configuration_menu",
                      :text => %q{<%= configurations_sidebar_menu_item t("social_authentication_methods"), admin_authentication_methods_path %>},
                      :disabled => false)
 
-Deface::Override.new(:virtual_path => "spree/admin/configurations/index",
-                     :name => "add_social_providers_to_configuration_menu",
-                     :insert_after => "[data-hook='admin_configurations_menu']",
-                     :partial => "spree/admin/shared/configurations_menu",
-                     :disabled => false)
-


### PR DESCRIPTION
I'm not sure if anyone else is running into this, but I was unable to precompile my deface views without removing this override.

Looks like it was last seen in [6efd86d2](https://github.com/spree/spree/commit/6efd86d24f3094966afa14ee07b87d715eadff2a) on spree/spree.
