### PR TITLE
Use apply_omniauth consistently

### DIFF
--- a/app/controllers/spree/omniauth_callbacks_controller.rb
+++ b/app/controllers/spree/omniauth_callbacks_controller.rb
@@ -22,7 +22,7 @@ class Spree::OmniauthCallbacksController < Devise::OmniauthCallbacksController
           elsif current_user
             current_user.apply_omniauth(auth_hash)
             current_user.save!
-           flash[:notice] = "Authentication successful."
+            flash[:notice] = "Authentication successful."
             redirect_back_or_default(account_url)
           else
             user = Spree::User.find_by_email(auth_hash['info']['email']) || Spree::User.new


### PR DESCRIPTION
Previous implementation means we don't get an access_token, and for folks overriding #apply_omniauth.
