### PR TITLE
Use resource object instead of the possible non existent @user instance ...

### DIFF
--- a/app/controllers/spree/user_registrations_controller_decorator.rb
+++ b/app/controllers/spree/user_registrations_controller_decorator.rb
@@ -7,9 +7,9 @@ Spree::UserRegistrationsController.class_eval do
   def build_resource(*args)
     super
     if session[:omniauth]
-      @user.apply_omniauth(session[:omniauth])
+      resource.apply_omniauth(session[:omniauth])
     end
-    @user
+    resource
   end
 
   def clear_omniauth


### PR DESCRIPTION
I was getting an undefined method `apply_omniauth' for nil:NilClass, I'm using spree_devise_auth, I suppose you're overriding the devise build_resource method, but looking at the devise code I found that the @user instance var is the result of the build_resource method, so, you can't use it inside the build_resource method, instead I used the resource object provide by devise
