### PR TITLE
Use url helper instead of raw url generated based on the site_url spree ...

### DIFF
--- a/app/views/spree/shared/_social.html.erb
+++ b/app/views/spree/shared/_social.html.erb
@@ -4,5 +4,5 @@
 
 <% Spree::AuthenticationMethod.available_for(@user).each do |method| %>
   <% img = "store/#{method.provider}_32.png" %>
-  <%= link_to(image_tag(img, :size => "32x32", :alt => "#{method.provider}"), user_omniauth_authorize_url(provider: method.provider), :title => t(:sign_in_with, :provider => method.provider)) if method.active %>
+  <%= link_to(image_tag(img, :size => "32x32", :alt => "#{method.provider}"), spree.user_omniauth_authorize_url(provider: method.provider), :title => t(:sign_in_with, :provider => method.provider)) if method.active %>
 <% end %>


### PR DESCRIPTION
I got confused with this, the first time I tried spree_social I was being redirected to http://demo.spreecommerce.com/users/auth, because I didn't change the spree_url preference, so to avoid this possible confusion, I think it is better to use the url helper
