### PR TITLE
Use Spree.t instead of t helper

### DIFF
--- a/app/overrides/admin_configuration_decorator.rb
+++ b/app/overrides/admin_configuration_decorator.rb
@@ -1,6 +1,6 @@
 Deface::Override.new(:virtual_path => "spree/admin/shared/_configuration_menu",
                      :name => "add_social_providers_link_configuration_menu",
                      :insert_bottom => "[data-hook='admin_configurations_sidebar_menu']",
-                     :text => %q{<%= configurations_sidebar_menu_item t("social_authentication_methods"), spree.admin_authentication_methods_path %>},
+                     :text => %q{<%= configurations_sidebar_menu_item Spree.t("social_authentication_methods"), spree.admin_authentication_methods_path %>},
                      :disabled => false)
 


### PR DESCRIPTION
t("social_authentication_methods") => Spree.t("social_authentication_methods")
