### PR TITLE
Fix translations on account page

### DIFF
--- a/app/views/spree/users/_social.html.erb
+++ b/app/views/spree/users/_social.html.erb
@@ -20,7 +20,7 @@
               <%= user_authentication.provider %>
             </div>
             <div class="uid columns two"><%= user_authentication.uid %></div>
-            <%= link_to "X", user_authentication, :confirm => "#{t(:remove_authentication_option_confirmation)}", :method => :delete, :class => "remove" %>
+            <%= link_to "X", user_authentication, :confirm => "#{Spree.t(:remove_authentication_option_confirmation)}", :method => :delete, :class => "remove" %>
           </div>
         <% end %>
         <div class="clear"></div>
@@ -28,7 +28,7 @@
     <% end %>
 
   <% end %>
-  <%= content_tag(:p, content_tag(:strong, t(:add_another_service_to_sign_in_with))) if Spree::AuthenticationMethod.available_for(spree_current_user).exists? %>
+  <%= content_tag(:p, content_tag(:strong, Spree.t(:add_another_service))) if Spree::AuthenticationMethod.available_for(spree_current_user).exists? %>
   <%= render :partial => "spree/shared/social" %>
 </div>
 


### PR DESCRIPTION
- Should use Spree.t as of ab06b36db2c9f4cf0c46e1905bf4325eec57d52c
- Fixed an incorrect translation key

As discussed in #92.
If you could please apply this to master and 2-0-stable. 1-3 and previous did not have translations under the spree namespace.
