### PR TITLE
Allow spree_core to handle merging guest orders

### DIFF
--- a/app/controllers/spree/omniauth_callbacks_controller.rb
+++ b/app/controllers/spree/omniauth_callbacks_controller.rb
@@ -37,8 +37,6 @@ class Spree::OmniauthCallbacksController < Devise::OmniauthCallbacksController
           end
 
           if current_order
-            user = spree_current_user || authentication.user
-            current_order.associate_user!(user)
             session[:guest_token] = nil
           end
         end


### PR DESCRIPTION
Steps to reproduce:
- Authenticate via spree_social
- Add items to cart
- Logout
- Visit any page which might check initialize a new order (doesn't need to add an item necessarily)
- Login again via spree_social

Expected behavior: Guest cart would be merged with user's last incomplete order
Actual behavior: User's last incomplete order is abandoned

Because spree_social always associates the guest cart with the newly logged in user, the last_incomplete_order for the user is always their current_order, which prevents [set_current_order](https://github.com/spree/spree/blob/6b44bc780cbf30f7b568ad785f2a8234235b8248/core/lib/spree/core/controller_helpers/order.rb#L63) from properly merging the _true_ last incomplete order.
