### PR TITLE
Update path_prefix default to match the old default

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ rails g spree_social:install
 bundle exec rake db:migrate
 ```
 
-Preference(optional): By default url will be '/user/auth/:provider'. If you wish to modify the url to: '/member/auth/:provider', '/profile/auth/:provider', or '/auth/:provider' then you can do this accordingly in your **config/initializers/spree.rb** file as described below -
+Preference(optional): By default url will be '/users/auth/:provider'. If you wish to modify the url to: '/member/auth/:provider', '/profile/auth/:provider', or '/auth/:provider' then you can do this accordingly in your **config/initializers/spree.rb** file as described below -
 
 ```ruby
 Spree::SocialConfig[:path_prefix] = 'member' # for /member/auth/:provider

--- a/app/models/spree/social_configuration.rb
+++ b/app/models/spree/social_configuration.rb
@@ -1,6 +1,6 @@
 # More on Spree's preference configuration - http://guides.spreecommerce.com/preferences.html#site_wide_preferences
 module Spree
   class SocialConfiguration < Preferences::Configuration
-    preference :path_prefix, :string, :default => 'user'
+    preference :path_prefix, :string, :default => 'users'
   end
 end


### PR DESCRIPTION
The old route was /users/auth/:provider and this has changed the default to /user/auth/:provider
I believe the default should not break existing apps that were relying on that route

This should be committed to 2-0-stable && 1-3-stable as well
