### PR TITLE
Spanish mx translations

### DIFF
--- a/app/controllers/spree/omniauth_callbacks_controller.rb
+++ b/app/controllers/spree/omniauth_callbacks_controller.rb
@@ -18,18 +18,18 @@ class Spree::OmniauthCallbacksController < Devise::OmniauthCallbacksController
           authentication = Spree::UserAuthentication.find_by_provider_and_uid(auth_hash['provider'], auth_hash['uid'])
 
           if authentication.present?
-            flash[:notice] = "Signed in successfully"
+            flash[:notice] = t("devise.omniauth_callbacks.success", :kind => auth_hash['provider'])
             sign_in_and_redirect :spree_user, authentication.user
           elsif spree_current_user
             spree_current_user.apply_omniauth(auth_hash)
             spree_current_user.save!
-            flash[:notice] = "Authentication successful."
+            flash[:notice] = t("devise.sessions.signed_in")
             redirect_back_or_default(account_url)
           else
             user = Spree::User.find_by_email(auth_hash['info']['email']) || Spree::User.new
             user.apply_omniauth(auth_hash)
             if user.save
-              flash[:notice] = "Signed in successfully."
+              flash[:notice] = t("devise.registrations.signed_up")
               sign_in_and_redirect :spree_user, user
             else
               session[:omniauth] = auth_hash.except('extra')

--- a/app/controllers/spree/user_authentications_controller.rb
+++ b/app/controllers/spree/user_authentications_controller.rb
@@ -6,7 +6,7 @@ class Spree::UserAuthenticationsController < Spree::StoreController
   def destroy
     @authentication = spree_current_user.user_authentications.find(params[:id])
     @authentication.destroy
-    flash[:notice] = "Successfully destroyed authentication method."
+    flash[:notice] = t('spree.authentications.destroy')
     redirect_to spree.account_path
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,8 @@
 en:
   spree:
     add_another_service: "Add another service to sign in with:"
+    authentications:
+      destroy: 'Successfully destroyed authentication method.'
     edit_social_method: "Editing Social Authentication Method"
     new_social_method: "New Authentication Method"
     one_more_step: 'One more step to complete your registration from %{kind}'

--- a/config/locales/es-MX.yml
+++ b/config/locales/es-MX.yml
@@ -1,0 +1,18 @@
+es-MX:
+  spree:
+    add_another_service: 'Añadir otro servicio para inicio de sesión:'
+    authentications:
+      destroy: 'Método de autenticación destruido exitosamente.'
+    edit_social_method: 'Editando metodo de autenticación'
+    new_social_method: 'Nuevo método de autenticación'
+    one_more_step: 'Un paso más para completar tu registro desde %{kind}'
+    remove_authentication_option_confirmation: '¿Está seguro que quiere eliminar este método de autenticación?'
+    sign_into_account: 'Puedes iniciar sesión usando:'
+    sign_in_through_service: 'Iniciar sesión a través de uno de estos servicios:'
+    social_api_key: 'API Key'
+    social_api_secret: 'API Secret'
+    social_authentication_methods: 'Métodos de autenticación'
+    social_authentication_methods_description: 'Configurar métodos de autenticación de OAuth'
+    social_provider: 'Proveedor social'
+    please_confirm_your_email: 'Por favor confirme su email para continuar'
+    sign_in_with: 'Autententicado con %{provider}'


### PR DESCRIPTION
- Internationalize hardcoded messages for:
  - OmniauthCallbacks
  - UserAuthentication
- Add es-MX translations
