### PR TITLE
Enabling set email with google_oauth2

### DIFF
--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -4,7 +4,7 @@ Spree.user_class.class_eval do
   devise :omniauthable
 
   def apply_omniauth(omniauth)
-    if omniauth['provider'] == "facebook"
+    if ["facebook", 'google_oauth2'].include? omniauth['provider']
       self.email = omniauth['info']['email'] if email.blank?
     end
     user_authentications.build(:provider => omniauth['provider'], :uid => omniauth['uid'])

--- a/spec/models/spree/user_decorator_spec.rb
+++ b/spec/models/spree/user_decorator_spec.rb
@@ -12,6 +12,17 @@ describe Spree::User do
       auths.should_receive(:build)
       user.apply_omniauth(omni_params)
     end
+    
+    context "omniauth params contains email" do
+      let(:user) { FactoryGirl.create(:user) {|user| user.email = nil} }
+      let(:omni_params) { {"provider" => "google_oauth2", "uid" => 12345, 'info' => {'email' => 'test@example.com'}} }
+      
+      it "should set email from omniauth params" do
+        auths.should_receive(:build)
+        user.apply_omniauth(omni_params)
+        user.email.should == 'test@example.com'
+      end
+    end
   end
 
   context "#password_required?" do


### PR DESCRIPTION
When you try to login with google, spree_social forces you to enter your email, no matter that they omniauth params contain the email.
