### PR TITLE
Fixes admin authentication methods pages + specs

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,10 @@
+guard "rspec", cmd: "bundle exec rspec", all_on_start: false, all_after_pass: false do
+  watch("spec/spec_helper.rb")                        { "spec" }
+  watch("config/routes.rb")                           { "spec/controllers" }
+  watch(%r{^spec/(.+)_spec\.rb$})                     { |m| "spec/#{m[1]}_spec.rb"}
+  watch(%r{^app/(.+)_decorator\.rb$})                 { |m| "spec/#{m[1]}_spec.rb" }
+  watch(%r{^app/(.+)\.rb$})                           { |m| "spec/#{m[1]}_spec.rb" }
+  watch(%r{^app/(.*)(\.erb)$})                        { |m| "spec/#{m[1]}#{m[2]}_spec.rb" }
+  watch(%r{^lib/(.+)\.rb$})                           { |m| "spec/#{m[1]}_spec.rb" }
+  watch(%r{^app/controllers/(.+)_(controller)\.rb$})  { |m| "spec/#{m[2]}s/#{m[1]}_#{m[2]}_spec.rb" }
+end

--- a/app/models/spree/authentication_method.rb
+++ b/app/models/spree/authentication_method.rb
@@ -1,4 +1,5 @@
 class Spree::AuthenticationMethod < ActiveRecord::Base
+  validates :provider, :api_key, :api_secret, presence: true
 
   def self.active_authentication_methods?
     where(:environment => ::Rails.env, :active => true).exists?

--- a/app/views/spree/admin/authentication_methods/_form.html.erb
+++ b/app/views/spree/admin/authentication_methods/_form.html.erb
@@ -1,7 +1,7 @@
 <div data-hook="admin_social_methods_form_fields" class="row">
   <div class="alpha five columns">
     <div data-hook="environment" class="field">
-      <%= auth_form.field_container :environment do %>
+      <%= f.field_container :environment do %>
         <%= label_tag nil, Spree.t(:environment) %>
         <%= collection_select(:authentication_method, :environment, Rails.configuration.database_configuration.keys, :to_s, :titleize, {}, {:class => 'select2 fullwidth'}) %>
       <% end %>
@@ -9,35 +9,35 @@
   </div>
   <div class="alpha five columns">
     <div data-hook="environment" class="field">
-      <%= auth_form.field_container :provider do %>
-        <%= auth_form.label :provider, Spree.t(:social_provider) %>
-        <%= auth_form.select :provider, SpreeSocial::OAUTH_PROVIDERS, {}, { :include_blank => false, :class => 'select2 fullwidth' } %>
+      <%= f.field_container :provider do %>
+        <%= f.label :provider, Spree.t(:social_provider) %>
+        <%= f.select :provider, SpreeSocial::OAUTH_PROVIDERS, {}, { :include_blank => false, :class => 'select2 fullwidth' } %>
       <% end %>
     </div>
   </div>
   <div class="alpha five columns">
     <div data-hook="environment" class="field">
-      <%= auth_form.field_container :api_key do %>
-        <%= auth_form.label :api_key, Spree.t(:social_api_key) %><br />
-        <%= auth_form.text_field :api_key, :class => 'fullwidth' %>
+      <%= f.field_container :api_key do %>
+        <%= f.label :api_key, Spree.t(:social_api_key) %> <span class="required">*</span><br />
+        <%= f.text_field :api_key, :class => 'fullwidth' %>
       <% end %>
     </div>
   </div>
   <div class="alpha five columns">
     <div data-hook="environment" class="field">
-      <%= auth_form.field_container :api_secret do %>
-        <%= auth_form.label :api_secret, Spree.t(:social_api_secret) %><br />
-        <%= auth_form.text_field :api_secret, :class => 'fullwidth' %>
+      <%= f.field_container :api_secret do %>
+        <%= f.label :api_secret, Spree.t(:social_api_secret) %> <span class="required">*</span><br />
+        <%= f.text_field :api_secret, :class => 'fullwidth' %>
       <% end %>
     </div>
   </div>
   <div class="alpha five columns">
     <div data-hook="environment" class="field">
-      <%= auth_form.field_container :active do %>
-        <span style="padding:0 10px 2px;"><%= auth_form.label :active, Spree.t(:active) %></span>
-        <%= auth_form.radio_button :active, :true %>
+      <%= f.field_container :active do %>
+        <span style="padding:0 10px 2px;"><%= f.label :active, Spree.t(:active) %></span>
+        <%= f.radio_button :active, :true %>
         <span style="padding:0 2px;"><%= Spree.t(:say_yes) %></span>
-        <%= auth_form.radio_button :active, :false %>
+        <%= f.radio_button :active, :false %>
         <span style="padding:0 2px"><%= Spree.t(:say_no) %></span>
       <% end %>
     </div>

--- a/app/views/spree/admin/authentication_methods/edit.html.erb
+++ b/app/views/spree/admin/authentication_methods/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:edit_social_method) %>
@@ -10,10 +10,9 @@
 
 <%= render 'spree/shared/error_messages', :target => @authentication_method %>
 
-<%= form_for(@authentication_method, :url => admin_authentication_method_path(@authentication_method), :method => :put) do |f| %>
+<%= form_for [:admin, @authentication_method] do |f| %>
   <fieldset class="no-border-top">
-    <%= render :partial => "form", :locals => { :auth_form => f } %>
-    <div class="clear"></div>
-    <%= render :partial => 'spree/admin/shared/edit_resource_links' %>
+    <%= render 'form', :f => f %>
+    <%= render 'spree/admin/shared/edit_resource_links' %>
   </fieldset>
 <% end %>

--- a/app/views/spree/admin/authentication_methods/new.html.erb
+++ b/app/views/spree/admin/authentication_methods/new.html.erb
@@ -1,4 +1,4 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:new_social_method) %>
@@ -8,12 +8,12 @@
   <li><%= link_to_with_icon 'icon-arrow-left', Spree.t(:back_to_authentication_methods_list), admin_authentication_methods_path, :class => 'button' %></li>
 <% end %>
 
-<%= render :partial => 'spree/shared/error_messages', :locals => { :target => @zone } %>
+<%= render 'spree/shared/error_messages', :target => @authentication_method %>
 
-<%= form_for [:admin, @authentication_method] do |auth_form| %>
+<%= form_for [:admin, @authentication_method] do |f| %>
   <fieldset class="no-border-top">
-    <%= render :partial => 'form', :locals => { :auth_form => auth_form } %>
-    <%= render :partial => 'spree/admin/shared/new_resource_links' %>
+    <%= render 'form', :f => f %>
+    <%= render 'spree/admin/shared/new_resource_links' %>
   </fieldset>
 <% end %>
 

--- a/spec/features/spree/admin/authentication_methods_configuration_spec.rb
+++ b/spec/features/spree/admin/authentication_methods_configuration_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper'
+
+feature 'Admin Authentication Methods', js: true do
+  stub_authorization!
+
+  context 'elements' do
+    scenario 'has configuration tab' do
+      visit spree.admin_path
+      click_link 'Configuration'
+      expect(page).to have_text 'SOCIAL AUTHENTICATION METHODS'
+    end
+  end
+
+  context 'when no auth methods exists' do
+    background do
+      visit spree.admin_path
+      click_link 'Configuration'
+      click_link 'Social Authentication Methods'
+    end
+
+    scenario 'can create new' do
+      expect(page).to have_text 'NO AUTHENTICATION METHODS FOUND, ADD ONE!'
+
+      click_link 'New Authentication Method'
+      expect(page).to have_text 'BACK TO AUTHENTICATION METHODS LIST'
+
+      select2 'Test', from: 'Environment'
+      select2 'Github', from: 'Social Provider'
+      fill_in 'API Key', with: 'KEY123'
+      fill_in 'API Secret', with: 'SEC123'
+
+      click_button 'Create'
+      expect(page).to have_text 'successfully created!'
+    end
+
+    scenario 'does not save with empty fields' do
+      click_link 'New Authentication Method'
+      click_button 'Create'
+      expect(page).to have_text 'errors prohibited this record from being saved'
+    end
+  end
+
+  context 'when auth method exists' do
+    given!(:authentication_method) do
+      Spree::AuthenticationMethod.create!(
+        provider: 'facebook',
+        api_key: 'fake',
+        api_secret: 'fake',
+        environment: Rails.env,
+        active: true)
+    end
+
+    background do
+      visit spree.admin_path
+      click_link 'Configuration'
+      click_link 'Social Authentication Methods'
+    end
+
+    scenario 'can be updated' do
+      within_row(1) do
+        click_icon :edit
+      end
+
+      fill_in 'API Key', with: 'fake'
+      fill_in 'API Secret', with: 'fake'
+
+      click_button 'Update'
+      expect(page).to have_text 'successfully updated!'
+    end
+
+    scenario 'can be deleted' do
+      within_row(1) do
+        click_icon :trash
+      end
+
+      page.driver.browser.switch_to.alert.accept unless Capybara.javascript_driver == :poltergeist
+
+      expect(page).to have_text 'successfully removed!'
+      expect(page).not_to have_text authentication_method.provider
+    end
+  end
+end

--- a/spec/features/spree/sign_in_spec.rb
+++ b/spec/features/spree/sign_in_spec.rb
@@ -3,7 +3,12 @@ require 'spec_helper'
 feature "signing in using Omniauth", js: true do
   context "facebook" do
     background do
-      Spree::AuthenticationMethod.create!(:provider => 'facebook', :environment => Rails.env, :active => true)
+      Spree::AuthenticationMethod.create!(
+        provider: 'facebook',
+        api_key: 'fake',
+        api_secret: 'fake',
+        environment: Rails.env,
+        active: true)
       OmniAuth.config.test_mode = true
       OmniAuth.config.mock_auth[:facebook] = {
         'provider' => 'facebook',
@@ -44,7 +49,12 @@ feature "signing in using Omniauth", js: true do
 
   context "twitter" do
     background do
-      Spree::AuthenticationMethod.create!(:provider => 'twitter', :environment => Rails.env, :active => true)
+      Spree::AuthenticationMethod.create!(
+        provider: 'twitter',
+        api_key: 'fake',
+        api_secret: 'fake',
+        environment: Rails.env,
+        active: true)
       OmniAuth.config.test_mode = true
       OmniAuth.config.mock_auth[:twitter] = {
         'provider' => 'twitter',

--- a/spec/lib/spree_social/engine_spec.rb
+++ b/spec/lib/spree_social/engine_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe SpreeSocial do
+  context 'constants' do
+    it { should be_const_defined(:OAUTH_PROVIDERS) }
+
+    it 'contain all providers' do
+      oauth_providers = [
+        ['Facebook', 'facebook'],
+        ['Twitter', 'twitter'],
+        ['Github', 'github'],
+        ['Google', 'google_oauth2']]
+      expect(described_class::OAUTH_PROVIDERS).to match_array oauth_providers
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,7 @@ require 'spree/testing_support/factories'
 require 'spree/testing_support/controller_requests'
 require 'spree/testing_support/authorization_helpers'
 require 'spree/testing_support/url_helpers'
+require 'spree/testing_support/capybara_ext'
 
 RSpec.configure do |config|
   config.mock_with :rspec

--- a/spree_social.gemspec
+++ b/spree_social.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'launchy'
   s.add_development_dependency 'coffee-rails', '~> 4.0.0'
   s.add_development_dependency 'sass-rails', '~> 4.0.0'
+  s.add_development_dependency 'guard-rspec'
 end


### PR DESCRIPTION
- Let `:provider`, `:api_key`, `:api_secret` be required fields. Also cleanup partials and add small starter spec for the extended engine classes that still yields quite red in simplecov.
