### PR TITLE
fix omniauths_callbacks_controller no method error

### DIFF
--- a/app/controllers/spree/omniauth_callbacks_controller.rb
+++ b/app/controllers/spree/omniauth_callbacks_controller.rb
@@ -35,6 +35,7 @@ class Spree::OmniauthCallbacksController < Devise::OmniauthCallbacksController
               session[:omniauth] = auth_hash.except('extra')
               flash[:notice] = Spree.t(:one_more_step, :kind => auth_hash['provider'].capitalize)
               redirect_to new_spree_user_registration_url
+              return
             end
           end
 


### PR DESCRIPTION
the if current_order block blows up when a user has no email with the provider, since there is no valid user to associate an order with.
