### PR TITLE
Added flag to skip sign up for providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,11 @@ It is easy to add any OAuth source, given there is an OmniAuth strategy gem for 
         SpreeSocial::OAUTH_PROVIDERS << ['LinkedIn', 'linkedin']
         SpreeSocial.init_provider('linkedin')
 
+  **Optional**: If you want to skip the sign up phase where the user has to provide an email and a password, add a third parameter to the provider entry and the Spree user will be created directly using the email field in the [Auth Hash Schema](https://github.com/intridea/omniauth/wiki/Auth-Hash-Schema):
+
+          SpreeSocial::OAUTH_PROVIDERS << ['LinkedIn', 'linkedin', 'true']
+          SpreeSocial.init_provider('linkedin')
+
 3. Activate your provider as usual (via initializer or admin interface).
 4. Override `spree/users/social` view to render OAuth links in preferred way for a new one to be displayed. Or alternatively, include to your CSS a definition for `.icon-spree-linkedin-circled` and an embedded icon font for LinkedIn from [fontello.com](http://fontello.com/) (the way existing icons for Facebook, Twitter, etc are implemented). You can also override CSS classes for other providers, `.icon-spree-<provider>-circled`, to use different font icons or classic background images, without having to override views.
 

--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -4,7 +4,8 @@ Spree.user_class.class_eval do
   devise :omniauthable
 
   def apply_omniauth(omniauth)
-    if %w(facebook google_oauth2).include? omniauth['provider']
+    skip_signup_providers = SpreeSocial::OAUTH_PROVIDERS.map { |p| p[1] if p[2] == 'true' }.compact
+    if skip_signup_providers.include? omniauth['provider']
       self.email = omniauth['info']['email'] if email.blank?
     end
     user_authentications.build(provider: omniauth['provider'], uid: omniauth['uid'])

--- a/app/views/spree/admin/authentication_methods/_form.html.erb
+++ b/app/views/spree/admin/authentication_methods/_form.html.erb
@@ -11,7 +11,7 @@
     <div data-hook="environment" class="field">
       <%= f.field_container :provider do %>
         <%= f.label :provider, Spree.t(:social_provider) %>
-        <%= f.select :provider, SpreeSocial::OAUTH_PROVIDERS, {}, { include_blank: false, class: 'select2 fullwidth' } %>
+        <%= f.select :provider, SpreeSocial::OAUTH_PROVIDERS.collect { |p| [ p[0], p[1] ] }, {}, { include_blank: false, class: 'select2 fullwidth' } %>
       <% end %>
     </div>
   </div>

--- a/lib/spree_social/engine.rb
+++ b/lib/spree_social/engine.rb
@@ -1,10 +1,10 @@
 module SpreeSocial
   OAUTH_PROVIDERS = [
-    %w(Facebook facebook),
-    %w(Twitter twitter),
-    %w(Github github),
-    %w(Google google_oauth2),
-    %w(Amazon amazon)
+    %w(Facebook facebook true),
+    %w(Twitter twitter false),
+    %w(Github github false),
+    %w(Google google_oauth2 true),
+    %w(Amazon amazon false)
   ]
 
   class Engine < Rails::Engine

--- a/spec/lib/spree_social/engine_spec.rb
+++ b/spec/lib/spree_social/engine_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe SpreeSocial do
 
     it 'contain all providers' do
       oauth_providers = [
-        %w(Amazon amazon),
-        %w(Facebook facebook),
-        %w(Twitter twitter),
-        %w(Github github),
-        %w(Google google_oauth2)
+        %w(Amazon amazon false),
+        %w(Facebook facebook true),
+        %w(Twitter twitter false),
+        %w(Github github false),
+        %w(Google google_oauth2 true)
       ]
       expect(described_class::OAUTH_PROVIDERS).to match_array oauth_providers
     end


### PR DESCRIPTION
I ran into this while adding a custom strategy for an additional OmniAuth access: Facebook and Google are the only providers who can create an user directly, without requiring the user to add an email address and a password. With this fix, you can set a third field when adding a new provider where you set if this provider **has to skip** the sign up phase.

```Ruby
SpreeSocial::OAUTH_PROVIDERS << ['LinkedIn', 'linkedin', 'true']
SpreeSocial.init_provider('linkedin')
```

By default, if you don't provide any value for this field, **it won't skip** the sign up page and the user **will be** promted for an email and a password.