### PR TITLE
remove environment setting

### DIFF
--- a/app/models/spree/authentication_method.rb
+++ b/app/models/spree/authentication_method.rb
@@ -2,11 +2,10 @@ class Spree::AuthenticationMethod < ActiveRecord::Base
   validates :provider, :api_key, :api_secret, presence: true
 
   def self.active_authentication_methods?
-    where(environment: ::Rails.env, active: true).exists?
+    where(active: true).exists?
   end
 
   scope :available_for, lambda { |user|
-    sc = where(environment: ::Rails.env)
     sc = sc.where(['provider NOT IN (?)', user.user_authentications.map(&:provider)]) if user && !user.user_authentications.empty?
     sc
   }

--- a/app/views/spree/admin/authentication_methods/_form.html.erb
+++ b/app/views/spree/admin/authentication_methods/_form.html.erb
@@ -2,7 +2,7 @@
   <div data-hook="admin_social_methods_form_fields">
     <div class="row">
       <div class="col-md-6">
-        <div data-hook="environment" class="form-group">
+        <div data-hook="provider" class="form-group">
           <%= f.label :provider, Spree.t(:social_provider) %>
           <%= f.select :provider, SpreeSocial::OAUTH_PROVIDERS.collect { |p| [ p[0], p[1] ] }, {}, { include_blank: false, class: 'select2' } %>
         </div>
@@ -11,13 +11,13 @@
 
     <div class="row">
       <div class="col-md-6">
-        <div data-hook="environment" class="form-group">
+        <div data-hook="api-key" class="form-group">
           <%= f.label :api_key, Spree.t(:social_api_key) %>
           <%= f.text_field :api_key, class: 'form-control' %>
         </div>
       </div>
       <div class="col-md-6">
-        <div data-hook="environment" class="form-group">
+        <div data-hook="api-secret" class="form-group">
           <%= f.label :api_secret, Spree.t(:social_api_secret) %>
           <%= f.text_field :api_secret, class: 'form-control' %>
         </div>
@@ -26,7 +26,7 @@
 
     <div class="row">
       <div class="col-md-6">
-        <div data-hook="environment" class="form-group">
+        <div data-hook="activity" class="form-group">
           <%= f.label :active, class: 'radio-inline' do %>
             <%= f.radio_button :active, :true %>
             <%= Spree.t(:active) %>

--- a/app/views/spree/admin/authentication_methods/_form.html.erb
+++ b/app/views/spree/admin/authentication_methods/_form.html.erb
@@ -1,13 +1,6 @@
 <%= form_for [:admin, resource] do |f| %>
-
   <div data-hook="admin_social_methods_form_fields">
     <div class="row">
-      <div class="col-md-6">
-        <div data-hook="environment" class="form-group">
-          <%= label_tag nil, Spree.t(:environment) %>
-          <%= collection_select :authentication_method, :environment, Rails.configuration.database_configuration.keys, :to_s, :titleize, {}, class: 'select2' %>
-        </div>
-      </div>
       <div class="col-md-6">
         <div data-hook="environment" class="form-group">
           <%= f.label :provider, Spree.t(:social_provider) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,7 +4,6 @@ en:
     omniauth_callbacks:
       success: "You are now signed in with your %{kind} account."
   spree:
-    environment: Environment
     user_was_not_valid: User was not valid.
     add_another_service: "Add another service to sign in with:"
     authentications:

--- a/spec/features/spree/admin/authentication_methods_configuration_spec.rb
+++ b/spec/features/spree/admin/authentication_methods_configuration_spec.rb
@@ -20,7 +20,6 @@ RSpec.feature 'Admin Authentication Methods', :js do
       click_link 'New Authentication Method'
       expect(page).to have_text 'Back To Authentication Methods List'
 
-      select2 'Test', from: 'Environment'
       select2 'Github', from: 'Social Provider'
       fill_in 'API Key', with: 'KEY123'
       fill_in 'API Secret', with: 'SEC123'
@@ -42,7 +41,6 @@ RSpec.feature 'Admin Authentication Methods', :js do
         provider: 'facebook',
         api_key: 'fake',
         api_secret: 'fake',
-        environment: Rails.env,
         active: true)
     end
 

--- a/spec/features/spree/sign_in_spec.rb
+++ b/spec/features/spree/sign_in_spec.rb
@@ -48,7 +48,6 @@ RSpec.feature 'signing in using Omniauth', :js do
         provider: 'twitter',
         api_key: 'fake',
         api_secret: 'fake',
-        environment: Rails.env,
         active: true)
       OmniAuth.config.test_mode = true
       OmniAuth.config.mock_auth[:twitter] = {


### PR DESCRIPTION
The environment option has been deprecated in several places. This PR removes environment from Spree Social.