### PR TITLE
Offline access scope is deprecated for Facebook

### DIFF
--- a/lib/spree_social/engine.rb
+++ b/lib/spree_social/engine.rb
@@ -55,7 +55,7 @@ module OmniAuth
                             'webos|amoi|novarra|cdm|alcatel|pocket|ipad|iphone|mobileexplorer|' \
                             'mobile'
       def request_phase
-        options[:scope] ||= 'email,offline_access'
+        options[:scope] ||= 'email'
         options[:display] = mobile_request? ? 'touch' : 'page'
         super
       end


### PR DESCRIPTION
https://developers.facebook.com/docs/roadmap/completed-changes/offline-access-removal

Offline access scope is deprecated and causes app developers / admins to see a warning and authorization ends with an error when trying to login.