### PR TITLE
Deleted deprecated facebook access scope

### DIFF
--- a/lib/spree_social/engine.rb
+++ b/lib/spree_social/engine.rb
@@ -55,7 +55,7 @@ module OmniAuth
                             'webos|amoi|novarra|cdm|alcatel|pocket|ipad|iphone|mobileexplorer|' \
                             'mobile'
       def request_phase
-        options[:scope] ||= 'email,offline_access'
+        options[:scope] ||= "email"
         options[:display] = mobile_request? ? 'touch' : 'page'
         super
       end


### PR DESCRIPTION
Deleted facebook deprecated offline access permission  from request_phase method.
https://developers.facebook.com/docs/roadmap/completed-changes/offline-access-removal