### PR TITLE
little refactor for authentication method

### DIFF
--- a/app/models/spree/authentication_method.rb
+++ b/app/models/spree/authentication_method.rb
@@ -7,7 +7,7 @@ class Spree::AuthenticationMethod < ActiveRecord::Base
 
   scope :available_for, lambda { |user|
     sc = where(environment: ::Rails.env)
-    sc = sc.where(['provider NOT IN (?)', user.user_authentications.map(&:provider)]) if user && !user.user_authentications.empty?
+    sc = sc.where.not(provider: user.user_authentications.pluck(:provider)) if user && !user.user_authentications.empty?
     sc
   }
 end


### PR DESCRIPTION
Since new spree versions works on rails >= 4.1 we can use `where.not` statement. Apart from this `pluck` is [faster](http://rubyinrails.com/2014/06/05/rails-pluck-vs-select-map-collect/) than `map`.