### PR TITLE
Remove deprecated Facebook permission for 2.2

### DIFF
--- a/lib/spree_social/engine.rb
+++ b/lib/spree_social/engine.rb
@@ -63,7 +63,7 @@ module OmniAuth
                               'webos|amoi|novarra|cdm|alcatel|pocket|ipad|iphone|mobileexplorer|' +
                               'mobile'
       def request_phase
-        options[:scope] ||= "email,offline_access"
+        options[:scope] ||= "email"
         options[:display] = mobile_request? ? 'touch' : 'page'
         super
       end


### PR DESCRIPTION
Fixes #162 for branch 2-2-stable the same way as in other branches. #167 is the same for 2-3-stable

https://developers.facebook.com/docs/roadmap/completed-changes/offline-access-removal