### PR TITLE
Set spree_core to >= 3.1.0 and < 4.0 versions

### DIFF
--- a/spree_social.gemspec
+++ b/spree_social.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_runtime_dependency 'spree_core', '~> 3.2.0.alpha'
+  s.add_runtime_dependency 'spree_core', '>= 3.1.0', '< 4.0'
   s.add_runtime_dependency 'omniauth'
   s.add_runtime_dependency 'oa-core'
   s.add_runtime_dependency 'omniauth-twitter'


### PR DESCRIPTION
This PR changes the version of `spree_core` in gemspec to point at `>= 3.1.0` and `< 4.0`.