### PR TITLE
lock ruby_dep ~> 1.3.0

### DIFF
--- a/spree_social.gemspec
+++ b/spree_social.gemspec
@@ -45,4 +45,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sass-rails', '~> 5.0.0'
   s.add_development_dependency 'guard-rspec'
   s.add_development_dependency 'rubocop', '>= 0.24.1'
+  s.add_development_dependency 'ruby_dep', '~> 1.3.0'
 end


### PR DESCRIPTION
ruby_dep >= 1.4 dropped support for ruby < 2.2.5