### PR TITLE
Ensure proper String#to_url behavior in Spree::AuthenticationMethod

### DIFF
--- a/app/models/spree/authentication_method.rb
+++ b/app/models/spree/authentication_method.rb
@@ -1,3 +1,5 @@
+require 'stringex'
+
 class Spree::AuthenticationMethod < ActiveRecord::Base
   validates :provider, :api_key, :api_secret, presence: true
 


### PR DESCRIPTION
Issue #156 

The same is used in [taxon.rb](https://github.com/spree/spree/blob/master/core/app/models/spree/taxon.rb#L2)

