### PR TITLE
Fix deprecation warnings about table_exists? method

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Alternatively you can ship keys as environment variables and create these Authen
 
 ```ruby
 # Ensure our environment is bootstrapped with a facebook connect app
-if ActiveRecord::Base.connection.table_exists? 'spree_authentication_methods'
+if ActiveRecord::Base.connection.data_source_exists? 'spree_authentication_methods'
   Spree::AuthenticationMethod.where(environment: Rails.env, provider: 'facebook').first_or_create do |auth_method|
     auth_method.api_key = ENV['FACEBOOK_APP_ID']
     auth_method.api_secret = ENV['FACEBOOK_APP_SECRET']

--- a/lib/spree_social/engine.rb
+++ b/lib/spree_social/engine.rb
@@ -37,7 +37,7 @@ module SpreeSocial
 
   # Setup all OAuth providers
   def self.init_provider(provider, scope='email')
-    return unless ActiveRecord::Base.connection.table_exists?('spree_authentication_methods')
+    return unless ActiveRecord::Base.connection.data_source_exists?('spree_authentication_methods')
     key, secret = nil
     Spree::AuthenticationMethod.where(environment: ::Rails.env).each do |auth_method|
       next unless auth_method.provider == provider


### PR DESCRIPTION
Fix the annoying warnings from Rails 5: 

    DEPRECATION WARNING: #table_exists? currently checks both tables and views. This behavior is deprecated and will be changed with Rails 5.1 to only check tables. Use #data_source_exists? instead.`
