### PR TITLE
Allow definition of pretty names for authentication methods

### DIFF
--- a/app/controllers/spree/omniauth_callbacks_controller.rb
+++ b/app/controllers/spree/omniauth_callbacks_controller.rb
@@ -8,8 +8,10 @@ class Spree::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     providers.each do |provider|
       class_eval <<-FUNCTION_DEFS, __FILE__, __LINE__ + 1
         def #{provider}
+          pretty_provider_name = Spree::AuthenticationMethod.name_presentation(auth_hash['provider'])
+
           if request.env['omniauth.error'].present?
-            flash[:error] = I18n.t('devise.omniauth_callbacks.failure', kind: auth_hash['provider'], reason: Spree.t(:user_was_not_valid))
+            flash[:error] = I18n.t('devise.omniauth_callbacks.failure', kind: pretty_provider_name, reason: Spree.t(:user_was_not_valid))
             redirect_back_or_default(root_url)
             return
           end
@@ -17,7 +19,7 @@ class Spree::OmniauthCallbacksController < Devise::OmniauthCallbacksController
           authentication = Spree::UserAuthentication.find_by_provider_and_uid(auth_hash['provider'], auth_hash['uid'])
 
           if authentication.present? and authentication.try(:user).present?
-            flash[:notice] = I18n.t('devise.omniauth_callbacks.success', kind: auth_hash['provider'])
+            flash[:notice] = I18n.t('devise.omniauth_callbacks.success', kind: pretty_provider_name)
             sign_in_and_redirect :spree_user, authentication.user
           elsif spree_current_user
             spree_current_user.apply_omniauth(auth_hash)
@@ -28,11 +30,11 @@ class Spree::OmniauthCallbacksController < Devise::OmniauthCallbacksController
             user = Spree::User.find_by_email(auth_hash['info']['email']) || Spree::User.new
             user.apply_omniauth(auth_hash)
             if user.save
-              flash[:notice] = I18n.t('devise.omniauth_callbacks.success', kind: auth_hash['provider'])
+              flash[:notice] = I18n.t('devise.omniauth_callbacks.success', kind: pretty_provider_name)
               sign_in_and_redirect :spree_user, user
             else
               session[:omniauth] = auth_hash.except('extra')
-              flash[:notice] = Spree.t(:one_more_step, kind: auth_hash['provider'].capitalize)
+              flash[:notice] = Spree.t(:one_more_step, kind: pretty_provider_name)
               redirect_to new_spree_user_registration_url
               return
             end

--- a/app/models/spree/authentication_method.rb
+++ b/app/models/spree/authentication_method.rb
@@ -12,4 +12,9 @@ class Spree::AuthenticationMethod < ActiveRecord::Base
     sc = sc.where.not(provider: user.user_authentications.pluck(:provider)) if user && !user.user_authentications.empty?
     sc
   }
+
+  def self.name_presentation(provider)
+    return '' unless provider
+    Spree.t("authentications.name_presentation.#{provider}")
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,6 +9,12 @@ en:
     add_another_service: "Add another service to sign in with:"
     authentications:
       destroy: 'Successfully destroyed authentication method.'
+      name_presentation:
+        facebook: Facebook
+        google_oauth2: Google
+        github: Github
+        twitter: Twitter
+        amazon: Amazon
     back_to_authentication_methods_list: "Back To Authentication Methods List"
     edit_social_method: "Editing Social Authentication Method"
     new_social_method: "New Authentication Method"


### PR DESCRIPTION
This is useful for notifications

Show:

![image](https://user-images.githubusercontent.com/9060346/36945503-1f4f5e46-1fc0-11e8-9df1-e15d9205ef50.png)

Instead of:

![image](https://user-images.githubusercontent.com/9060346/36945510-3d6e6976-1fc0-11e8-8993-a44153c860c0.png)
