### PR TITLE
Fixing issue with amazon login causing it to skip grabbing email

### DIFF
--- a/lib/spree_social/engine.rb
+++ b/lib/spree_social/engine.rb
@@ -4,7 +4,7 @@ module SpreeSocial
     %w(Twitter twitter false),
     %w(Github github false),
     %w(Google google_oauth2 true),
-    %w(Amazon amazon false)
+    %w(Amazon amazon true)
   ]
 
   class Engine < Rails::Engine


### PR DESCRIPTION
Email is provided inside the amazon auth_hash. There is no need to skip and redirect.