### PR TITLE
Added Deface as dependency

### DIFF
--- a/spree_social.gemspec
+++ b/spree_social.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'omniauth-github'
   s.add_runtime_dependency 'omniauth-google-oauth2'
   s.add_runtime_dependency 'omniauth-amazon'
+  s.add_runtime_dependency 'deface', '~> 1.0'
 
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'capybara-screenshot'


### PR DESCRIPTION
Since Spree 4.0 [doesn't require deface](https://github.com/spree/spree/pull/9394) we need to require it here