### PR TITLE
[spree 4.2.0.rc5] Include `Spree::Core::ControllerHelpers::Currency` if possible

### DIFF
--- a/app/controllers/spree/omniauth_callbacks_controller.rb
+++ b/app/controllers/spree/omniauth_callbacks_controller.rb
@@ -3,6 +3,9 @@ class Spree::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   include Spree::Core::ControllerHelpers::Order
   include Spree::Core::ControllerHelpers::Auth
   include Spree::Core::ControllerHelpers::Store
+  if defined?(Spree::Core::ControllerHelpers::Currency)
+    include Spree::Core::ControllerHelpers::Currency
+  end
 
   def self.provides_callback_for(*providers)
     providers.each do |provider|


### PR DESCRIPTION

`#current_currency` is extracted to that module.

fixes https://github.com/spree-contrib/spree_social/issues/246

ref. https://github.com/spree/spree/pull/10713